### PR TITLE
Fix sed replacement on macOS

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -132,7 +132,10 @@ fi
 
 
 # Replace ID for gene_id if necessary
-sed -i 's/ID/gene_id/g' "$gff_input"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' 's/ID/gene_id/g' "$gff_input"
+else
+  sed -i 's/ID/gene_id/g' "$gff_input"
 
 # Set up alignment based on paired/single end
 if [ -z "$fastq_input2" ]; then


### PR DESCRIPTION
This PR fixes #1 

As explained in the issue, the additional `''` tells `sed` not to use a backup file, allowing the command to succeed.