### PR TITLE
Fix: update Paired variable when R2 provided

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -159,6 +159,7 @@ else
   filename1=$(basename "$fastq_input1")
   sample=${filename1%_R1.fastq*}
   input_fastq_option="$fastq_input1 $fastq_input2"
+  Paired="TRUE"
 fi
 
 # Create output directories


### PR DESCRIPTION
This PR fixes #3 

When the second file (R2) is detected, the `Paired` variable is updated to reflect the paired-end status.